### PR TITLE
Update Homebrew-install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cat alternative written in Go.
 ### Homebrew
 
 ```console
-$ brew install koki-develop/tap/gat
+$ brew install gat
 ```
 
 ### `go install`


### PR DESCRIPTION
`gat` is now in Homebrew proper, so taps aren't needed anymore.