### PR TITLE
Add Arch Linux packages to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ $ brew install gat
 $ brew install koki-develop/tap/gat
 ```
 
+### Arch Linux(AUR)
+```console
+$ yay -S gat # Latest version
+
+$ yay -S gat-git # Git version
+
+$ yay -S gat-bin # Binary version from Releases
+```
+
 ### `go install`
 
 ```console


### PR DESCRIPTION
Greetings!

I decided to make `gat` packages for the Arch Linux distributive. These packages are already in the AUR, so I decided to add them to the Readme of the project.
I think the users will be very pleased